### PR TITLE
Add name attr to the plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,5 +21,11 @@ export default function createExtraScopePlugin(extra) {
     }
   }
 
+  // stable identifier that will not be dropped by minification unless the whole
+  // module
+  // is unused
+  /*#__PURE__*/
+  Object.defineProperty(extraScopePlugin, 'name', { value: 'extraScopePlugin' })
+
   return extraScopePlugin
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,7 @@ export default function createExtraScopePlugin(extra) {
     }
   }
 
-  // stable identifier that will not be dropped by minification unless the whole
-  // module
-  // is unused
-  /*#__PURE__*/
+  // stable identifier that will not be dropped by minification
   Object.defineProperty(extraScopePlugin, 'name', { value: 'extraScopePlugin' })
 
   return extraScopePlugin


### PR DESCRIPTION
The name of the function is lost due to the minification step, this will prevent issues from Styled Components (at least) from failing without requiring to do this before using the plugin.

Related to https://github.com/styled-components/styled-components/issues/3005